### PR TITLE
Import `gitlab_security` cops from `gitlab-styles`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
   Exclude:
     - 'lib/rubocop/cop/gitlab_security/*.rb'
     - 'spec/rubocop/cop/gitlab_security/*.rb'
+    # avoid linting installed gems when running in GitHub Actions
+    - '**/vendor/bundle/**/*' 
 Naming/FileName:
   Exclude:
     - lib/rubocop-eightyfourcodes.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,10 @@ require:
   - rubocop-rspec
   - rubocop-rake
 
+AllCops:
+  Exclude:
+    - 'lib/rubocop/cop/gitlab_security/*.rb'
+    - 'spec/rubocop/cop/gitlab_security/*.rb'
 Naming/FileName:
   Exclude:
     - lib/rubocop-eightyfourcodes.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,22 +8,23 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    diff-lcs (1.5.1)
-    json (2.7.2)
-    language_server-protocol (3.17.0.3)
+    diff-lcs (1.6.0)
+    json (2.10.2)
+    language_server-protocol (3.17.0.4)
+    lint_roller (1.1.0)
     parallel (1.26.3)
-    parser (3.3.5.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
-    regexp_parser (2.9.2)
+    regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -31,28 +32,34 @@ GEM
     rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
-    rubocop (1.67.0)
+    rspec-support (3.13.2)
+    rubocop (1.74.0)
       json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 2.4, < 3.0)
-      rubocop-ast (>= 1.32.2, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.3)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.40.0)
       parser (>= 3.3.1.0)
-    rubocop-rake (0.6.0)
-      rubocop (~> 1.0)
-    rubocop-rspec (3.1.0)
-      rubocop (~> 1.61)
+    rubocop-rake (0.7.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
+    rubocop-rspec (3.5.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
-    unicode-display_width (2.6.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
     yard (0.9.37)
 
 PLATFORMS
+  arm64-darwin-23
   ruby
 
 DEPENDENCIES
@@ -65,4 +72,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.22
+   2.6.4

--- a/lib/rubocop/cop/eightyfourcodes_cops.rb
+++ b/lib/rubocop/cop/eightyfourcodes_cops.rb
@@ -3,3 +3,10 @@
 require_relative 'eighty_four_codes/command_literal_injection'
 require_relative 'eighty_four_codes/ensure_redirect'
 require_relative 'eighty_four_codes/ruby_version_file'
+
+require_relative 'gitlab_security/json_serialization'
+require_relative 'gitlab_security/public_send'
+require_relative 'gitlab_security/redirect_to_params_update'
+require_relative 'gitlab_security/send_file_params'
+require_relative 'gitlab_security/sql_injection'
+require_relative 'gitlab_security/system_command_injection'

--- a/lib/rubocop/cop/gitlab_security/deep_munge.rb
+++ b/lib/rubocop/cop/gitlab_security/deep_munge.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module GitlabSecurity
+      # Checks for disabling the deep munge security control.
+      #
+      # Disabling this security setting can leave the application open to unsafe
+      # query generation
+      #
+      # @example
+      #
+      #   # bad
+      #   config.action_dispatch.perform_deep_munge = false
+      #
+      # See CVE-2012-2660, CVE-2012-2694, and CVE-2013-0155.
+      class DeepMunge < RuboCop::Cop::Base
+        MSG = 'Never disable the deep munge security option.'
+
+        # @!method disable_deep_munge?(node)
+        def_node_matcher :disable_deep_munge?, <<-PATTERN
+          (send
+            (send (send nil? :config) :action_dispatch) :perform_deep_munge=
+              { (false) (send true :!) }
+          )
+        PATTERN
+
+        def on_send(node)
+          return unless disable_deep_munge?(node)
+
+          add_offense(node.loc.selector)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/gitlab_security/json_serialization.rb
+++ b/lib/rubocop/cop/gitlab_security/json_serialization.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module GitlabSecurity
+      # Checks for `to_json` / `as_json` without allowing via `only`.
+      #
+      # Either method called on an instance of a `Serializer` class will be
+      # ignored. Associations included via `include` are subject to the same
+      # rules.
+      #
+      # @example
+      #
+      #   # bad
+      #   render json: @user.to_json
+      #   render json: @user.to_json(except: %i[password])
+      #   render json: @user.to_json(
+      #     only: %i[username],
+      #     include: [:identities]
+      #   )
+      #
+      #   # acceptable
+      #   render json: UserSerializer.new.to_json
+      #
+      #   # good
+      #   render json: @user.to_json(only: %i[name username])
+      #   render json: @user.to_json(
+      #     only: %i[username],
+      #     include: { identities: { only: %i[provider] } }
+      #   )
+      #
+      # See https://gitlab.com/gitlab-org/gitlab-ce/issues/29661
+      class JsonSerialization < RuboCop::Cop::Base
+        MSG = "Don't use `%s` without specifying `only`"
+
+        # Check for `to_json` sent to any object that's not a Hash literal or
+        # Serializer instance
+        # @!method json_serialization?(node)
+        def_node_matcher :json_serialization?, <<~PATTERN
+          (send !{nil? hash #serializer?} ${:to_json :as_json} $...)
+        PATTERN
+
+        # Check if node is a `only: ...` pair
+        # @!method only_pair?(node)
+        def_node_matcher :only_pair?, <<~PATTERN
+          (pair (sym :only) ...)
+        PATTERN
+
+        # Check if node is a `include: {...}` pair
+        # @!method include_pair?(node)
+        def_node_matcher :include_pair?, <<~PATTERN
+          (pair (sym :include) (hash $...))
+        PATTERN
+
+        # Check for a `only: [...]` pair anywhere in the node
+        # @!method contains_only?(node)
+        def_node_search :contains_only?, <<~PATTERN
+          (pair (sym :only) (array ...))
+        PATTERN
+
+        # Check for `SomeConstant.new`
+        # @!method constant_init(node)
+        def_node_search :constant_init, <<~PATTERN
+          (send (const nil? $_) :new ...)
+        PATTERN
+
+        def on_send(node)
+          matched = json_serialization?(node)
+          return unless matched
+
+          @_has_top_level_only = false
+          @method = matched.first
+
+          if matched.last.nil? || matched.last.empty?
+            @offense_found = true
+            # Empty `to_json` call
+            add_offense(node.loc.selector, message: format_message)
+          else
+            check_arguments(node, matched)
+          end
+        end
+
+        private
+
+        def format_message
+          format(MSG, @method)
+        end
+
+        def serializer?(node)
+          constant_init(node).any? { |name| name.to_s.end_with?('Serializer') }
+        end
+
+        def check_arguments(node, matched)
+          options = matched.last.first
+
+          # If `to_json` was given an argument that isn't a Hash, we don't
+          # know what to do here, so just move along
+          return unless options.hash_type?
+
+          options.each_child_node do |child_node|
+            check_pair(child_node)
+          end
+
+          return unless requires_only?
+
+          @offense_found = true
+
+          # Add a top-level offense for the entire argument list, but only if
+          # we haven't yet added any offenses to the child Hash values (such
+          # as `include`)
+          add_offense(node.children.last, message: format_message)
+        end
+
+        def check_pair(pair)
+          if only_pair?(pair)
+            @_has_top_level_only = true
+          elsif include_pair?(pair)
+            includes = pair.value
+
+            includes.each_child_node do |child_node|
+              next if contains_only?(child_node)
+
+              @offense_found = true
+              add_offense(child_node, message: format_message)
+            end
+          end
+        end
+
+        def requires_only?
+          return false if @_has_top_level_only
+
+          !@offense_found
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/gitlab_security/public_send.rb
+++ b/lib/rubocop/cop/gitlab_security/public_send.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module GitlabSecurity
+      # Checks for the use of `public_send`, `send`, and `__send__` methods.
+      #
+      # If passed untrusted input these methods can be used to execute arbitrary
+      # methods on behalf of an attacker.
+      #
+      # @example
+      #
+      #   # bad
+      #   myobj.public_send("#{params[:foo]}")
+      #
+      #   # good
+      #   case params[:foo].to_s
+      #   when 'choice1'
+      #     items.choice1
+      #   when 'choice2'
+      #     items.choice2
+      #   when 'choice3'
+      #     items.choice3
+      #   end
+      class PublicSend < RuboCop::Cop::Base
+        MSG = 'Avoid using `%s`.'
+
+        RESTRICT_ON_SEND = %i[send public_send __send__].freeze
+
+        # @!method send?(node)
+        def_node_matcher :send?, <<-PATTERN
+          (call _ ${:send :public_send :__send__} ...)
+        PATTERN
+
+        def on_send(node)
+          send?(node) do |match|
+            next unless node.arguments?
+
+            add_offense(node.loc.selector, message: format(MSG, match))
+          end
+        end
+
+        alias_method :on_csend, :on_send
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/gitlab_security/redirect_to_params_update.rb
+++ b/lib/rubocop/cop/gitlab_security/redirect_to_params_update.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module GitlabSecurity
+      # Check for use of redirect_to(params.update())
+      #
+      # Passing user params to the redirect_to method provides an open redirect
+      #
+      # @example
+      #
+      #   # bad
+      #   redirect_to(params.update(action: 'main'))
+      #
+      #   # good
+      #   redirect_to(allowed(params))
+      #
+      class RedirectToParamsUpdate < RuboCop::Cop::Base
+        MSG = 'Avoid using `redirect_to(params.%<name>s(...))`. ' \
+          'Only pass allowed arguments into redirect_to() (e.g. not including `host`)'
+
+        # @!method redirect_to_params_update_node(node)
+        def_node_matcher :redirect_to_params_update_node, <<-PATTERN
+           (send nil? :redirect_to $(send (send nil? :params) ${:update :merge} ...))
+        PATTERN
+
+        def on_send(node)
+          selected, name = redirect_to_params_update_node(node)
+          return unless name
+
+          message = format(MSG, name: name)
+
+          add_offense(selected, message: message)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/gitlab_security/send_file_params.rb
+++ b/lib/rubocop/cop/gitlab_security/send_file_params.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module GitlabSecurity
+      # Check for use of send_file(..., params[], ...)
+      #
+      # Passing user params to the send_file() method allows directory traversal
+      #
+      # @example
+      #
+      #   # bad
+      #   send_file("/tmp/myproj/" + params[:filename])
+      #
+      #   # good (verify directory)
+
+      #   basename = File.expand_path("/tmp/myproj")
+      #   filename = File.expand_path(File.join(basename, @file.public_filename))
+      #   raise if basename != filename
+      #   send_file filename, disposition: 'inline'
+      #
+      class SendFileParams < RuboCop::Cop::Base
+        MSG = 'Do not pass user provided params directly to send_file(), ' \
+          'verify the path with file.expand_path() first.'
+
+        # @!method params_node?(node)
+        def_node_search :params_node?, <<-PATTERN
+           (send (send nil? :params) ... )
+        PATTERN
+
+        def on_send(node)
+          return unless node.command?(:send_file)
+          return unless node.arguments.any? { |e| params_node?(e) }
+
+          add_offense(node.loc.selector)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/gitlab_security/sql_injection.rb
+++ b/lib/rubocop/cop/gitlab_security/sql_injection.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module GitlabSecurity
+      # Check for use of where("name = '#{params[:name]}'")
+      #
+      # Passing user input to where() without parameterization can result in SQL Injection
+      #
+      # @example
+      #
+      #   # bad
+      #   u = User.where("name = '#{params[:name]}'")
+      #
+      #   # good (parameters)
+      #   u = User.where("name = ? AND id = ?", params[:name], params[:id])
+      #   u = User.where(name: params[:name], id: params[:id])
+      #
+      class SqlInjection < RuboCop::Cop::Base
+        MSG = 'Parameterize all user-input passed to where(), do not directly embed user input in SQL queries.'
+
+        # @!method where_user_input?(node)
+        def_node_matcher :where_user_input?, <<-PATTERN
+          (send _ :where ...)
+        PATTERN
+
+        # @!method string_var_string?(node)
+        def_node_matcher :string_var_string?, <<-PATTERN
+          (dstr (str ...) (begin ...) (str ...) ...)
+        PATTERN
+
+        def on_send(node)
+          return unless where_user_input?(node)
+          return unless node.arguments.any? { |e| string_var_string?(e) }
+
+          add_offense(node.loc.selector)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/gitlab_security/system_command_injection.rb
+++ b/lib/rubocop/cop/gitlab_security/system_command_injection.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module GitlabSecurity
+      # Check for use of system("/bin/ls #{params[:file]}")
+      #
+      # Passing user input to system() without sanitization and parameterization can result in command injection
+      #
+      # @example
+      #
+      #   # bad
+      #   system("/bin/ls #{filename}")
+      #
+      #   # good (parameters)
+      #   system("/bin/ls", filename)
+      #   # even better
+      #   exec("/bin/ls", shell_escape(filename))
+      #
+      class SystemCommandInjection < RuboCop::Cop::Base
+        MSG = 'Do not include variables in the command name for system(). ' \
+          'Use parameters "system(cmd, params)" or exec() instead.'
+
+        # @!method system_var?(node)
+        def_node_matcher :system_var?, <<-PATTERN
+          (dstr (str ...) (begin ...) ...)
+        PATTERN
+
+        def on_send(node)
+          return unless node.command?(:system)
+          return unless node.arguments.any? { |e| system_var?(e) }
+
+          add_offense(node.loc.selector)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/gitlab_security/deep_munge_spec.rb
+++ b/spec/rubocop/cop/gitlab_security/deep_munge_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../../../lib/rubocop/cop/gitlab_security/deep_munge'
+
+RSpec.describe RuboCop::Cop::GitlabSecurity::DeepMunge do
+  it 'ignores setting to true' do
+    expect_no_offenses(<<~RUBY)
+      config.action_dispatch.perform_deep_munge = true
+    RUBY
+  end
+
+  it 'adds an offense for setting it to `false`' do
+    expect_offense(<<~RUBY)
+      config.action_dispatch.perform_deep_munge = false
+                             ^^^^^^^^^^^^^^^^^^ Never disable the deep munge security option.
+
+      config.action_dispatch.perform_deep_munge = !true
+                             ^^^^^^^^^^^^^^^^^^ Never disable the deep munge security option.
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/gitlab_security/json_serialization_spec.rb
+++ b/spec/rubocop/cop/gitlab_security/json_serialization_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../../../lib/rubocop/cop/gitlab_security/json_serialization'
+
+RSpec.describe RuboCop::Cop::GitlabSecurity::JsonSerialization do
+  def message_for(method)
+    format("Don't use `%s` without specifying `only`", method)
+  end
+
+  shared_examples 'an upstanding constable' do |method|
+    it "ignores calls except `#{method}`" do
+      expect_no_offenses('render json: foo')
+    end
+
+    context "with `#{method}` and without options" do
+      it 'does nothing when sent to nil receiver' do
+        expect_no_offenses(method.to_s)
+      end
+
+      it 'does nothing when sent to a Hash' do
+        expect_no_offenses("{}.#{method}")
+      end
+
+      it 'does nothing when sent to a Serializer instance' do
+        aggregate_failures do
+          expect_no_offenses(<<~RUBY)
+            IssueSerializer.new.represent(issuable).#{method}
+          RUBY
+
+          expect_no_offenses(<<~RUBY)
+            MergeRequestSerializer
+              .new(current_user: current_user, project: issuable.project)
+              .represent(issuable)
+              .#{method}
+          RUBY
+        end
+      end
+
+      it 'adds an offense when sent to any other receiver' do
+        expect_offense(<<-'RUBY', method: method, message: message_for(method))
+          foo.%{method}
+              ^{method} %{message}
+        RUBY
+      end
+    end
+
+    context "with `#{method}` and with options" do
+      it 'does nothing when provided `only`' do
+        expect_no_offenses(<<~RUBY)
+          render json: @issue.#{method}(only: [:name, :username])
+        RUBY
+      end
+
+      it 'does nothing when provided `only` and `methods`' do
+        expect_no_offenses(<<~RUBY)
+          render json: @issue.#{method}(
+            only: [:name, :username],
+            methods: [:avatar_url]
+          )
+        RUBY
+      end
+
+      it 'adds an offense to `include`d attributes without `only` option' do
+        expect_offense(<<~RUBY)
+          render json: @issue.#{method}(
+            include: {
+              milestone: {},
+              ^^^^^^^^^^^^^ #{message_for(method)}
+              assignee: { methods: :avatar_url },
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message_for(method)}
+              author: { only: %i[foo bar] },
+            }
+          )
+        RUBY
+      end
+
+      it 'handles a top-level `only` with child `include`s' do
+        expect_offense(<<~RUBY)
+          render json: @issue.#{method}(
+            only: [:foo, :bar],
+            include: {
+              assignee: { methods: :avatar_url },
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message_for(method)}
+              author: { only: %i[foo bar] }
+            }
+          )
+        RUBY
+      end
+
+      it 'adds an offense for `include: [...]`' do
+        # Spacing is off on the highlight due to interpolation
+        expect_offense(<<~RUBY)
+          render json: @issue.#{method}(include: %i[foo bar baz])
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^ #{message_for(method)}
+        RUBY
+      end
+
+      it 'adds an offense for `except`' do
+        # Spacing is off on the highlight due to interpolation
+        expect_offense(<<~RUBY)
+          render json: @issue.#{method}(except: [:private_token])
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^ #{message_for(method)}
+        RUBY
+      end
+    end
+  end
+
+  include_examples 'an upstanding constable', :to_json
+  include_examples 'an upstanding constable', :as_json
+end

--- a/spec/rubocop/cop/gitlab_security/public_send_spec.rb
+++ b/spec/rubocop/cop/gitlab_security/public_send_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../../../lib/rubocop/cop/gitlab_security/public_send'
+
+RSpec.describe RuboCop::Cop::GitlabSecurity::PublicSend do
+  shared_examples 'an upstanding constable' do |method|
+    it "adds an offense for `#{method}`" do
+      expect_offense(<<~RUBY, method: method)
+        basic.%{method}(:bar)
+              ^{method} Avoid using `%{method}`.
+      RUBY
+    end
+
+    it "adds an offense for `#{method}` with arguments" do
+      expect_offense(<<~RUBY, method: method)
+        args.%{method}(:bar, baz: true)
+             ^{method} Avoid using `%{method}`.
+      RUBY
+    end
+
+    it "adds offense for `#{method}` on `nil` receiver" do
+      expect_offense(<<~RUBY, method: method)
+        %{method}(:foo)
+        ^{method} Avoid using `%{method}`.
+      RUBY
+    end
+
+    it "adds an offense for `#{method}` when using a safe accessor" do
+      expect_offense(<<~RUBY, method: method)
+        basic&.%{method}(:bar)
+               ^{method} Avoid using `%{method}`.
+      RUBY
+    end
+
+    it "ignores `#{method}` with no argument" do
+      expect_no_offenses("foo.#{method}")
+    end
+  end
+
+  include_examples 'an upstanding constable', :send
+  include_examples 'an upstanding constable', :public_send
+  include_examples 'an upstanding constable', :__send__
+end

--- a/spec/rubocop/cop/gitlab_security/redirect_to_params_update_spec.rb
+++ b/spec/rubocop/cop/gitlab_security/redirect_to_params_update_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../../../lib/rubocop/cop/gitlab_security/redirect_to_params_update'
+
+RSpec.describe RuboCop::Cop::GitlabSecurity::RedirectToParamsUpdate do
+  it 'does not flag correct use' do
+    expect_no_offenses(<<~RUBY)
+      redirect_to allowed(params)
+      redirect_to(allowed(params))
+    RUBY
+  end
+
+  it 'flags incorrect use' do
+    expect_offense(<<~RUBY)
+      redirect_to(params.update(action: 'main'))
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using `redirect_to(params.update(...))`. [...]
+      redirect_to(params.merge(action: 'main'))
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using `redirect_to(params.merge(...))`. [...]
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/gitlab_security/send_file_params_spec.rb
+++ b/spec/rubocop/cop/gitlab_security/send_file_params_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../../../lib/rubocop/cop/gitlab_security/send_file_params'
+
+RSpec.describe RuboCop::Cop::GitlabSecurity::SendFileParams do
+  it 'does not flag correct use' do
+    expect_no_offenses(<<~RUBY)
+      basename = File.expand_path("/tmp/myproj")
+      filename = File.expand_path(File.join(basename, @file.public_filename))
+      raise if basename != filename
+      send_file filename, disposition: 'inline'
+    RUBY
+  end
+
+  it 'flags incorrect use' do
+    expect_offense(<<~RUBY)
+      send_file("/tmp/myproj/" + params[:filename])
+      ^^^^^^^^^ Do not pass user provided params [...]
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/gitlab_security/sql_injection_spec.rb
+++ b/spec/rubocop/cop/gitlab_security/sql_injection_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../../../lib/rubocop/cop/gitlab_security/sql_injection'
+
+RSpec.describe RuboCop::Cop::GitlabSecurity::SqlInjection do
+  it 'does not flag correct use' do
+    expect_no_offenses(<<~RUBY)
+      User.where("name = ? AND id = ?", params[:name], params[:id])
+      User.where(name: params[:name], id: params[:id])
+    RUBY
+  end
+
+  it 'flags incorrect use' do
+    expect_offense(<<~'RUBY')
+      User.where("name = '#{params[:name]}'")
+           ^^^^^ Parameterize all user-input passed to where(), [...]
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/gitlab_security/system_command_injection_spec.rb
+++ b/spec/rubocop/cop/gitlab_security/system_command_injection_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../../../lib/rubocop/cop/gitlab_security/system_command_injection'
+
+RSpec.describe RuboCop::Cop::GitlabSecurity::SystemCommandInjection do
+  it 'does not flag correct use' do
+    expect_no_offenses(<<~RUBY)
+      system("/bin/ls", filename)
+      exec("/bin/ls", shell_escape(filename))
+    RUBY
+  end
+
+  it 'flags incorrect use' do
+    expect_offense(<<~'RUBY')
+      system("/bin/ls #{filename}")
+      ^^^^^^ Do not include variables in the command name for system(). [...]
+    RUBY
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,4 +14,10 @@ RSpec.configure do |config|
 
   config.order = :random
   Kernel.srand config.seed
+
+  config.define_derived_metadata(file_path: %r{/spec/rubocop/cop/}) do |meta|
+    meta[:type] = :cop_spec
+  end
+
+  config.include_context 'config', type: :cop_spec
 end


### PR DESCRIPTION
From https://gitlab.com/gitlab-org/ruby/gems/gitlab-styles/-/tree/7b918480effb661d4255b83ec753af7c5e0c1d68

What I did

    cd ~/src
    git clone https://gitlab.com/gitlab-org/ruby/gems/gitlab-styles
    cd ~/eightyfourcodes/rubocop-eighty-four-codes
    rm Gemfile.lock
    bundle
    cp -r ~/src/gitlab-styles/lib/rubocop/cop/gitlab_security lib/rubocop/cop
    cp -r ~/src/gitlab-styles/spec/rubocop/cop/gitlab_security spec/rubocop/cop

Updated our spec helper with minimal additions to get specs passing.