### PR TITLE
Enable all new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ plugins:
   - rubocop-rake
 
 AllCops:
+  NewCops: enable
   Exclude:
     - 'lib/rubocop/cop/gitlab_security/*.rb'
     - 'spec/rubocop/cop/gitlab_security/*.rb'

--- a/rubocop-eightyfourcodes.gemspec
+++ b/rubocop-eightyfourcodes.gemspec
@@ -16,6 +16,10 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 2.6.0'
 
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(__dir__) do
@@ -25,6 +29,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'rubocop'
+  spec.add_dependency 'rubocop'
   spec.extra_rdoc_files = ['LICENSE.md', 'README.md']
 end

--- a/spec/rubocop/cop/eighty_four_codes/command_literal_injection_spec.rb
+++ b/spec/rubocop/cop/eighty_four_codes/command_literal_injection_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::EightyFourCodes::CommandLiteralInjection, :config d
     end
 
     it 'allows %x without arguments' do
-      expect_no_offenses(<<-'RUBY')
+      expect_no_offenses(<<-RUBY)
          %x(cat /var/log/syslog)
       RUBY
     end
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::EightyFourCodes::CommandLiteralInjection, :config d
     end
 
     it 'allows %x without arguments' do
-      expect_no_offenses(<<-'RUBY')
+      expect_no_offenses(<<-RUBY)
         `cat /var/log/syslog`
       RUBY
     end


### PR DESCRIPTION
The list of not enabled cops printed when running "bundle e rake rubocop" was so long.

Fixes

- Gemspec/RequireMFA: metadata['rubygems_mfa_required'] must be set to 'true'.
- Gemspec/AddRuntimeDependency: Use add_dependency instead of add_runtime_dependency.
- Style/RedundantHeredocDelimiterQuotes: Remove the redundant heredoc delimiter quotes, use <<-RUBY instead.
