### PR TITLE
Add workflow for Trusted Publishing to RubyGems.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  release:
+    if: github.repository == '84codes/rubocop-eighty-four-codes'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+      - uses: rubygems/configure-rubygems-credentials@v1.0.0
+      # ensure gem can be built and installed, push to rubygems.org
+      - run: gem build rubocop-eightyfourcodes
+      - run: gem install *.gem
+      - run: gem push *.gem


### PR DESCRIPTION
See https://guides.rubygems.org/trusted-publishing/

This will push a release to RubyGems.org when we push a tag to the repo.
