### PR TITLE
Don't use open-ended dependency on rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-eightyfourcodes (0.0.3)
-      rubocop
+      rubocop (< 2)
 
 GEM
   remote: https://rubygems.org/

--- a/rubocop-eightyfourcodes.gemspec
+++ b/rubocop-eightyfourcodes.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.require_paths = ['lib']
-  spec.add_dependency 'rubocop'
+  spec.add_dependency 'rubocop', '< 2'
   spec.extra_rdoc_files = ['LICENSE.md', 'README.md']
 end


### PR DESCRIPTION
Avoids this warning when building the gem:

    $ gem build rubocop-eightyfourcodes
    WARNING:  open-ended dependency on rubocop (>= 0) is not recommended
      use a bounded requirement, such as "~> x.y"
    WARNING:  See https://guides.rubygems.org/specification-reference/ for help
      Successfully built RubyGem
      Name: rubocop-eightyfourcodes
      Version: 0.0.3
      File: rubocop-eightyfourcodes-0.0.3.gem
