### PR TITLE
Upload attestation of gem provenance at release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,7 @@ jobs:
       # ensure gem can be built and installed, push to rubygems.org
       - run: gem build rubocop-eightyfourcodes
       - run: gem install *.gem
-      - run: gem push *.gem
+      - run: |
+          ruby -S gem exec sigstore-cli:0.2.1 sign *.gem --bundle attestation.sigstore.json
+      - run: |
+          gem push --attestation attestation.sigstore.json *.gem


### PR DESCRIPTION
Since last year, RubyGems.org accepts Sigstore Bundles with Gem Pushes: https://github.com/rubygems/rfcs/blob/33b5ebddeb161e847cd950cc77fbaf667ff180bd/text/0000-rubygems.org-sigstore-bundles.md

This uses sigstore-cli[1][2] to generate a sigstore bundle[3] that we include in the push to RubyGems.org.

I got this command from https://github.com/rubygems/release-gem/pull/11 I've tested this over at https://rubygems.org/gems/slenips https://github.com/spinels/slenips/blob/ae7cc4fa6d777f49ea0860acf0426b187c50a1fe/.github/workflows/release.yml#L25-L32

See also
- https://segiddins.github.io/are-we-attested-yet/
- https://blog.rubygems.org/2025/03/19/february-rubygems-updates.html
- https://blog.trailofbits.com/2024/11/14/attestations-a-new-generation-of-signatures-on-pypi/

1: https://github.com/sigstore/sigstore-ruby
2: https://rubygems.org/gems/sigstore-cli
3: https://docs.sigstore.dev/about/bundle/
